### PR TITLE
change xAPI Definitions and rename variables

### DIFF
--- a/.github/workflows/docker-CI.yml
+++ b/.github/workflows/docker-CI.yml
@@ -2,7 +2,7 @@ name: Docker Build and Push
 
 on:
   push:
-    branches: [ master, develop, java17 ]
+    branches: [ master, develop, xapi ]
 
 jobs:
   build:

--- a/.github/workflows/docker-CI.yml
+++ b/.github/workflows/docker-CI.yml
@@ -2,7 +2,7 @@ name: Docker Build and Push
 
 on:
   push:
-    branches: [ master, develop, xapi ]
+    branches: [ master, develop ]
 
 jobs:
   build:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -61,7 +61,8 @@ set_in_service_config pgsqlUser ${PGSQL_USER}
 set_in_service_config pgsqlPassword ${PGSQL_PASSWORD}
 set_in_service_config pgsqlDB ${PGSQL_DB}
 
-
+set_in_service_config xapiUrl ${XAPI_URL}
+set_in_service_config xapiHomepage ${XAPI_HOMEPAGE}
 # prevent glob expansion in lib/*
 set -f
 LAUNCH_COMMAND='java -cp lib/* --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED i5.las2peer.tools.L2pNodeLauncher -s service -p '"${LAS2PEER_PORT} ${SERVICE_EXTRA_ARGS}"

--- a/etc/i5.las2peer.services.tmitocar.TmitocarService.properties
+++ b/etc/i5.las2peer.services.tmitocar.TmitocarService.properties
@@ -14,3 +14,5 @@ pgsqlUser =
 pgsqlPassword = 
 pgsqlDB = 
 address = http://127.0.0.1:8080
+xapiUrl = 
+xapiHomepage = 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/las2peer-tmitocar-service/.project
+++ b/las2peer-tmitocar-service/.project
@@ -10,9 +10,15 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
 	<filteredResources>
 		<filter>

--- a/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
+++ b/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
@@ -364,6 +364,7 @@ public class TmitocarService extends RESTService {
 							if (uuid!=null){
 								// user has accepted
 							LrsCredentials lrsCredentials = getLrsCredentialsByCourse(Integer.parseInt(courseAndTask[0]));
+							System.out.println(lrsCredentials);
 							if(lrsCredentials!=null){
 								JSONObject xapi = prepareXapiStatement(uuid, "read", body.getTopic(), Integer.parseInt(courseAndTask[0]),Integer.parseInt(courseAndTask[1]),  graphFileId.toString(), feedbackFileId.toString(), sourceFileId);
 								String toEncode = lrsCredentials.getClientKey()+":"+lrsCredentials.getClientSecret();
@@ -1344,7 +1345,7 @@ public class TmitocarService extends RESTService {
 			}
 			try{
 				JSONObject acc = (JSONObject) p.parse(new String("{'account': { 'name': '" + user
-					+ "', 'homePage': "+ xapiHomepage + "}}"));
+					+ "', 'homePage': '"+ xapiHomepage.toString() + "'}}"));
 				
 				LrsCredentials res = service.getLrsCredentialsByCourse(courseId);
 				URL url = new URL(service.lrsURL + "/data/xAPI/statements?agent=" + acc.toString());

--- a/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
+++ b/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
@@ -365,7 +365,7 @@ public class TmitocarService extends RESTService {
 								// user has accepted
 							LrsCredentials lrsCredentials = getLrsCredentialsByCourse(Integer.parseInt(courseAndTask[0]));
 							if(lrsCredentials!=null){
-								JSONObject xapi = prepareXapiStatement(uuid, "read", body.getTopic(), Integer.parseInt(courseAndTask[0]),Integer.parseInt(courseAndTask[1]),  graphFileId.toString(), feedbackFileId.toString(), sourceFileId);
+								JSONObject xapi = prepareXapiStatement(uuid, "received_feedback", body.getTopic(), Integer.parseInt(courseAndTask[0]),Integer.parseInt(courseAndTask[1]),  graphFileId.toString(), feedbackFileId.toString(), sourceFileId);
 								String toEncode = lrsCredentials.getClientKey()+":"+lrsCredentials.getClientSecret();
 								String encodedString = Base64.encodeBytes(toEncode.getBytes());
 								sendXAPIStatement(xapi, encodedString);
@@ -947,7 +947,7 @@ public class TmitocarService extends RESTService {
 				// user has accepted
 				LrsCredentials lrsCredentials = service.getLrsCredentialsByCourse(courseId);
 				if(lrsCredentials!=null){
-					JSONObject xapi = service.prepareXapiStatement(uuid, "sent", topic, courseId, task, uploaded.toString(),null,null);
+					JSONObject xapi = service.prepareXapiStatement(uuid, "uploaded_task", topic, courseId, task, uploaded.toString(),null,null);
 					String toEncode = lrsCredentials.getClientKey()+":"+lrsCredentials.getClientSecret();
 					String encodedString = Base64.encodeBytes(toEncode.getBytes());
 
@@ -1090,7 +1090,7 @@ public class TmitocarService extends RESTService {
 				// user has accepted
 				LrsCredentials lrsCredentials = service.getLrsCredentialsByCourse(courseId);
 				if(lrsCredentials!=null){
-					JSONObject xapi = service.prepareXapiStatement(uuid, "sent", topic, courseId, Integer.parseInt(label2), uploaded.toString(),null,null);
+					JSONObject xapi = service.prepareXapiStatement(uuid, "received_feedback", topic, courseId, Integer.parseInt(label2), uploaded.toString(),null,null);
 					String toEncode = lrsCredentials.getClientKey()+":"+lrsCredentials.getClientSecret();
 					String encodedString = Base64.encodeBytes(toEncode.getBytes());
 					service.sendXAPIStatement(xapi, encodedString);
@@ -1793,17 +1793,16 @@ public class TmitocarService extends RESTService {
 		actor.put("account", account);
 		System.out.println(account);
 		JSONObject verb = (JSONObject) p
-				.parse(new String("{'display':{'en-US':'"+verbId+"'},'id':'" + xapiUrl + "/definitions/chat/verbs/" +verbId+"'}"));
+				.parse(new String("{'display':{'en-US':'"+verbId+"'},'id':'" + xapiUrl + "/definitions/mwb/verb/" +verbId+"'}"));
 		JSONObject object = (JSONObject) p
 				.parse(new String("{'definition':{'interactionType':'other', 'name':{'en-US':'" + topic
-						+ "'}, 'extensions:': {'" + xapiUrl + "/definitions/mwb/object/course': {'id': '" + course + "'}}, 'description':{'en-US':'" + topic
-						+ "'}, 'type':'"+ xapiUrl + "/definitions/chat/activities/file'},'id':'https://tech4comp.de/tmitocar/file/"
-						+ fileId + "', 'objectType':'Activity'}"));
+						+ "'}, 'extensions:': {'" + xapiUrl + "/definitions/mwb/object/course': {'id': " + course + "}}, 'description':{'en-US':'" + topic
+						+ "'}, 'type':'"+ xapiUrl + "/definitions/chat/activities/file'}, 'objectType':'Activity'}"));
 		JSONObject context = (JSONObject) p.parse(new String(
 				"{'extensions':{'" + xapiUrl + "/definitions/mwb/extensions/context/activity_data':{'id':'"
 						+ fileId + "','topic':'"
 						+ topic
-						+ "','course':'" + course + "','taskNr':'" + taskNr + "'}}}"));
+						+ "','taskNr':" + taskNr + "}}}"));
 						if (fileId2!= null && source != null){
 							context = (JSONObject) p.parse(new String(
 				"{'extensions':{'"+ xapiUrl + "/definitions/mwb/extensions/context/activity_data':{'graphfileId':'"
@@ -1811,7 +1810,7 @@ public class TmitocarService extends RESTService {
 						+ fileId2 + "','source':'"
 						+ source + "','topic':'"
 						+ topic
-						+ "','course':'" + course + "','taskNr':'" + taskNr + "'}}}"));
+						+ ",'taskNr':" + taskNr + "}}}"));
 						}
 		JSONObject xAPI = new JSONObject();
 

--- a/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
+++ b/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
@@ -365,7 +365,7 @@ public class TmitocarService extends RESTService {
 								// user has accepted
 							LrsCredentials lrsCredentials = getLrsCredentialsByCourse(Integer.parseInt(courseAndTask[0]));
 							if(lrsCredentials!=null){
-								JSONObject xapi = prepareXapiStatement(uuid, "uploaded_task", body.getTopic(), Integer.parseInt(courseAndTask[0]),Integer.parseInt(courseAndTask[1]),  graphFileId.toString(), feedbackFileId.toString(), sourceFileId);
+								JSONObject xapi = prepareXapiStatement(uuid, "received_feedback", body.getTopic(), Integer.parseInt(courseAndTask[0]),Integer.parseInt(courseAndTask[1]),  graphFileId.toString(), feedbackFileId.toString(), sourceFileId);
 								String toEncode = lrsCredentials.getClientKey()+":"+lrsCredentials.getClientSecret();
 								String encodedString = Base64.encodeBytes(toEncode.getBytes());
 								sendXAPIStatement(xapi, encodedString);
@@ -772,10 +772,12 @@ public class TmitocarService extends RESTService {
 
 					// Parse the JSON string into a JSONObject
 					JSONObject jsonObject = (JSONObject) parser.parse(jsonStr);
-					System.out.println("getCommonWords: \n");
+					System.out.println("getCommonWords:");
 					System.out.println(jsonObject);
 					String formattedMessage = "Danke, besprich das gern auch mit Kommiliton:innen und deinem/r Dozent:in. Wenn ich jetzt deinen Text und den Expertentext vergleiche, dann tauchen in beiden Texten folgende Begriffe als wesentlich auf:\n";
 					JSONArray bSchnittmengeArray = (JSONArray) jsonObject.get("BegriffeSchnittmenge");
+					System.out.println("SchnittmengenArray:");
+					System.out.println(bSchnittmengeArray);
 					formattedMessage += formatJSONArray(bSchnittmengeArray);
 					formattedMessage += "Wenn du nochmal an die Aufgabenstellung denkst, fehlen Schlüsselbegriffe, die du noch ergänzen würdest? Wenn ja, welche?";
 					JSONObject resBody = new JSONObject();
@@ -836,12 +838,13 @@ public class TmitocarService extends RESTService {
 					System.out.println(jsonObject);
 					String formattedMessage = "Übrigens gibt es noch folgende Begriffe, die im Expertentext genannt wurden, aber noch nicht in deinem Text auftauchen::\n";
 					formattedMessage += "-------------------------\n";
-					JSONArray bSchnittmengeArray = (JSONArray) jsonObject.get("BegriffeDiffB");
-					formattedMessage += formatJSONArray(bSchnittmengeArray);
+					JSONArray bDiffArray = (JSONArray) jsonObject.get("BegriffeDiffB");
+					formattedMessage += formatJSONArray(bDiffArray);
 					formattedMessage += "Überleg nochmal, welche davon du sinnvoll in deinen Text einbauen kannst und möchtest.";
 					JSONObject resBody = new JSONObject();
-					resBody.put("formattedMessage",formatJSONArray(bSchnittmengeArray));
-					System.out.println(bSchnittmengeArray);
+					resBody.put("formattedMessage",formatJSONArray(bDiffArray));
+					System.out.println("DiffArray");
+					System.out.println(bDiffArray);
 					return Response.ok(resBody.toString()).build();
 				} catch (MongoException me) {
 					System.err.println(me);
@@ -1091,7 +1094,7 @@ public class TmitocarService extends RESTService {
 				// user has accepted
 				LrsCredentials lrsCredentials = service.getLrsCredentialsByCourse(courseId);
 				if(lrsCredentials!=null){
-					JSONObject xapi = service.prepareXapiStatement(uuid, "received_feedback", topic, courseId, Integer.parseInt(label2), uploaded.toString(),null,null);
+					JSONObject xapi = service.prepareXapiStatement(uuid, "uploaded_task", topic, courseId, Integer.parseInt(label2), uploaded.toString(),null,null);
 					String toEncode = lrsCredentials.getClientKey()+":"+lrsCredentials.getClientSecret();
 					String encodedString = Base64.encodeBytes(toEncode.getBytes());
 					service.sendXAPIStatement(xapi, encodedString);

--- a/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
+++ b/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
@@ -1810,7 +1810,7 @@ public class TmitocarService extends RESTService {
 						+ fileId2 + "','source':'"
 						+ source + "','topic':'"
 						+ topic
-						+ ",'taskNr':" + taskNr + "}}}"));
+						+ "','taskNr':" + taskNr + "}}}"));
 						}
 		JSONObject xAPI = new JSONObject();
 

--- a/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
+++ b/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
@@ -1797,7 +1797,7 @@ public class TmitocarService extends RESTService {
 		JSONObject object = (JSONObject) p
 				.parse(new String("{'definition':{'interactionType':'other', 'name':{'en-US':'" + topic
 						+ "'}, 'extensions':{'" + xapiUrl + "/definitions/mwb/object/course': {'id': " + course + "}}, 'description':{'en-US':'" + topic
-						+ "'}, 'type':'"+ xapiUrl + "/definitions/chat/activities/file'}, 'objectType':'Activity'}"));
+						+ "'}, 'type':'"+ xapiUrl + "/definitions/chat/activities/file'}, 'id': '" + fileId + "','objectType':'Activity'}"));
 		JSONObject context = (JSONObject) p.parse(new String(
 				"{'extensions':{'" + xapiUrl + "/definitions/mwb/extensions/context/activity_data':{'id':'"
 						+ fileId + "','topic':'"

--- a/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
+++ b/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
@@ -1796,7 +1796,7 @@ public class TmitocarService extends RESTService {
 				.parse(new String("{'display':{'en-US':'"+verbId+"'},'id':'" + xapiUrl + "/definitions/mwb/verb/" +verbId+"'}"));
 		JSONObject object = (JSONObject) p
 				.parse(new String("{'definition':{'interactionType':'other', 'name':{'en-US':'" + topic
-						+ "'}, 'extensions:': {'" + xapiUrl + "/definitions/mwb/object/course': {'id': " + course + "}}, 'description':{'en-US':'" + topic
+						+ "'}, 'extensions':{'" + xapiUrl + "/definitions/mwb/object/course': {'id': " + course + "}}, 'description':{'en-US':'" + topic
 						+ "'}, 'type':'"+ xapiUrl + "/definitions/chat/activities/file'}, 'objectType':'Activity'}"));
 		JSONObject context = (JSONObject) p.parse(new String(
 				"{'extensions':{'" + xapiUrl + "/definitions/mwb/extensions/context/activity_data':{'id':'"

--- a/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
+++ b/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
@@ -772,12 +772,8 @@ public class TmitocarService extends RESTService {
 
 					// Parse the JSON string into a JSONObject
 					JSONObject jsonObject = (JSONObject) parser.parse(jsonStr);
-					System.out.println("getCommonWords:");
-					System.out.println(jsonObject);
 					String formattedMessage = "Danke, besprich das gern auch mit Kommiliton:innen und deinem/r Dozent:in. Wenn ich jetzt deinen Text und den Expertentext vergleiche, dann tauchen in beiden Texten folgende Begriffe als wesentlich auf:\n";
 					JSONArray bSchnittmengeArray = (JSONArray) jsonObject.get("BegriffeSchnittmenge");
-					System.out.println("SchnittmengenArray:");
-					System.out.println(bSchnittmengeArray);
 					formattedMessage += formatJSONArray(bSchnittmengeArray);
 					formattedMessage += "Wenn du nochmal an die Aufgabenstellung denkst, fehlen Schlüsselbegriffe, die du noch ergänzen würdest? Wenn ja, welche?";
 					JSONObject resBody = new JSONObject();
@@ -835,7 +831,6 @@ public class TmitocarService extends RESTService {
 
 					// Parse the JSON string into a JSONObject
 					JSONObject jsonObject = (JSONObject) parser.parse(jsonStr);
-					System.out.println(jsonObject);
 					String formattedMessage = "Übrigens gibt es noch folgende Begriffe, die im Expertentext genannt wurden, aber noch nicht in deinem Text auftauchen::\n";
 					formattedMessage += "-------------------------\n";
 					JSONArray bDiffArray = (JSONArray) jsonObject.get("BegriffeDiffB");
@@ -843,8 +838,6 @@ public class TmitocarService extends RESTService {
 					formattedMessage += "Überleg nochmal, welche davon du sinnvoll in deinen Text einbauen kannst und möchtest.";
 					JSONObject resBody = new JSONObject();
 					resBody.put("formattedMessage",formatJSONArray(bDiffArray));
-					System.out.println("DiffArray");
-					System.out.println(bDiffArray);
 					return Response.ok(resBody.toString()).build();
 				} catch (MongoException me) {
 					System.err.println(me);

--- a/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
+++ b/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
@@ -365,7 +365,7 @@ public class TmitocarService extends RESTService {
 								// user has accepted
 							LrsCredentials lrsCredentials = getLrsCredentialsByCourse(Integer.parseInt(courseAndTask[0]));
 							if(lrsCredentials!=null){
-								JSONObject xapi = prepareXapiStatement(uuid, "received_feedback", body.getTopic(), Integer.parseInt(courseAndTask[0]),Integer.parseInt(courseAndTask[1]),  graphFileId.toString(), feedbackFileId.toString(), sourceFileId);
+								JSONObject xapi = prepareXapiStatement(uuid, "uploaded_task", body.getTopic(), Integer.parseInt(courseAndTask[0]),Integer.parseInt(courseAndTask[1]),  graphFileId.toString(), feedbackFileId.toString(), sourceFileId);
 								String toEncode = lrsCredentials.getClientKey()+":"+lrsCredentials.getClientSecret();
 								String encodedString = Base64.encodeBytes(toEncode.getBytes());
 								sendXAPIStatement(xapi, encodedString);
@@ -772,7 +772,8 @@ public class TmitocarService extends RESTService {
 
 					// Parse the JSON string into a JSONObject
 					JSONObject jsonObject = (JSONObject) parser.parse(jsonStr);
-
+					System.out.println("getCommonWords: \n")
+					System.out.println(jsonObject);
 					String formattedMessage = "Danke, besprich das gern auch mit Kommiliton:innen und deinem/r Dozent:in. Wenn ich jetzt deinen Text und den Expertentext vergleiche, dann tauchen in beiden Texten folgende Begriffe als wesentlich auf:\n";
 					JSONArray bSchnittmengeArray = (JSONArray) jsonObject.get("BegriffeSchnittmenge");
 					formattedMessage += formatJSONArray(bSchnittmengeArray);
@@ -832,7 +833,7 @@ public class TmitocarService extends RESTService {
 
 					// Parse the JSON string into a JSONObject
 					JSONObject jsonObject = (JSONObject) parser.parse(jsonStr);
-
+					System.out.println(jsonObject);
 					String formattedMessage = "Übrigens gibt es noch folgende Begriffe, die im Expertentext genannt wurden, aber noch nicht in deinem Text auftauchen::\n";
 					formattedMessage += "-------------------------\n";
 					JSONArray bSchnittmengeArray = (JSONArray) jsonObject.get("BegriffeDiffB");
@@ -840,7 +841,7 @@ public class TmitocarService extends RESTService {
 					formattedMessage += "Überleg nochmal, welche davon du sinnvoll in deinen Text einbauen kannst und möchtest.";
 					JSONObject resBody = new JSONObject();
 					resBody.put("formattedMessage",formatJSONArray(bSchnittmengeArray));
-					
+					System.out.println(bSchnittmengeArray);
 					return Response.ok(resBody.toString()).build();
 				} catch (MongoException me) {
 					System.err.println(me);
@@ -1821,7 +1822,6 @@ public class TmitocarService extends RESTService {
 		xAPI.put("actor", actor);
 		xAPI.put("object", object);
 		xAPI.put("verb", verb);
-		System.out.println(xAPI);
 		return xAPI;
 	}
 

--- a/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
+++ b/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
@@ -362,7 +362,7 @@ public class TmitocarService extends RESTService {
 								// user has accepted
 							LrsCredentials lrsCredentials = getLrsCredentialsByCourse(Integer.parseInt(courseAndTask[0]));
 							if(lrsCredentials!=null){
-								JSONObject xapi = prepareXapiStatement(uuid, "received_file", body.getTopic(), Integer.parseInt(courseAndTask[0]),Integer.parseInt(courseAndTask[1]),  graphFileId.toString(), feedbackFileId.toString(), sourceFileId);
+								JSONObject xapi = prepareXapiStatement(uuid, "read", body.getTopic(), Integer.parseInt(courseAndTask[0]),Integer.parseInt(courseAndTask[1]),  graphFileId.toString(), feedbackFileId.toString(), sourceFileId);
 								String toEncode = lrsCredentials.getClientKey()+":"+lrsCredentials.getClientSecret();
 								String encodedString = Base64.encodeBytes(toEncode.getBytes());
 								sendXAPIStatement(xapi, encodedString);
@@ -944,7 +944,7 @@ public class TmitocarService extends RESTService {
 				// user has accepted
 				LrsCredentials lrsCredentials = service.getLrsCredentialsByCourse(courseId);
 				if(lrsCredentials!=null){
-					JSONObject xapi = service.prepareXapiStatement(uuid, "sent_file", topic, courseId, task, uploaded.toString(),null,null);
+					JSONObject xapi = service.prepareXapiStatement(uuid, "sent", topic, courseId, task, uploaded.toString(),null,null);
 					String toEncode = lrsCredentials.getClientKey()+":"+lrsCredentials.getClientSecret();
 					String encodedString = Base64.encodeBytes(toEncode.getBytes());
 
@@ -1087,7 +1087,7 @@ public class TmitocarService extends RESTService {
 				// user has accepted
 				LrsCredentials lrsCredentials = service.getLrsCredentialsByCourse(courseId);
 				if(lrsCredentials!=null){
-					JSONObject xapi = service.prepareXapiStatement(uuid, "sent_file", topic, courseId, Integer.parseInt(label2), uploaded.toString(),null,null);
+					JSONObject xapi = service.prepareXapiStatement(uuid, "sent", topic, courseId, Integer.parseInt(label2), uploaded.toString(),null,null);
 					String toEncode = lrsCredentials.getClientKey()+":"+lrsCredentials.getClientSecret();
 					String encodedString = Base64.encodeBytes(toEncode.getBytes());
 					service.sendXAPIStatement(xapi, encodedString);
@@ -1384,9 +1384,9 @@ public class TmitocarService extends RESTService {
 						// JSONObject definition = (JSONObject) object.get("definition");
 						JSONObject extensions = (JSONObject) context.get("extensions");// assignmentNumber
 						// check if its not a delete statement
-						if (extensions.get("https://tech4comp.de/xapi/context/extensions/file") != null && verb.get("id").toString().contains("sent_file")) {
+						if (extensions.get("https://xapi.tech4comp.dbis.rwth-aachen.de/definitions/generic/extensions/context/assignment") != null && verb.get("id").toString().contains("sent")) {
 							JSONObject fileDetails = (JSONObject) extensions
-									.get("https://tech4comp.de/xapi/context/extensions/file");
+									.get("https://xapi.tech4comp.dbis.rwth-aachen.de/definitions/generic/extensions/context/assignment");
 							if (fileDetails.get("taskNr") != null) {
 								String assignmentName = fileDetails.get("taskNr").toString();
 								// JSONObject name = (JSONObject) definition.get("name");
@@ -1785,24 +1785,24 @@ public class TmitocarService extends RESTService {
 		JSONObject account = new JSONObject();
 
 		account.put("name", user);
-		account.put("homePage", "https://chat.tech4comp.dbis.rwth-aachen.de");
+		account.put("homePage", "https://workbench.tech4comp.dbis.rwth-aachen.de");
 		actor.put("account", account);
 		
 		JSONObject verb = (JSONObject) p
-				.parse(new String("{'display':{'en-US':'"+verbId+"'},'id':'https://tech4comp.de/xapi/verb/"+verbId+"'}"));
+				.parse(new String("{'display':{'en-US':'"+verbId+"'},'id':'https://xapi.tech4comp.dbis.rwth-aachen.de/definitions/chat/verbs/"+verbId+"'}"));
 		JSONObject object = (JSONObject) p
 				.parse(new String("{'definition':{'interactionType':'other', 'name':{'en-US':'" + topic
 						+ "'}, 'description':{'en-US':'" + topic
-						+ "'}, 'type':'https://tech4comp.de/xapi/activitytype/file'},'id':'https://tech4comp.de/tmitocar/file/"
+						+ "'}, 'type':'https://xapi.tech4comp.dbis.rwth-aachen.de/definitions/chat/activities/file'},'id':'https://tech4comp.de/tmitocar/file/"
 						+ fileId + "', 'objectType':'Activity'}"));
 		JSONObject context = (JSONObject) p.parse(new String(
-				"{'extensions':{'https://tech4comp.de/xapi/context/extensions/file':{'id':'"
+				"{'extensions':{'https://xapi.tech4comp.dbis.rwth-aachen.de/definitions/generic/extensions/context/assignment':{'id':'"
 						+ fileId + "','topic':'"
 						+ topic
 						+ "','course':'" + course + "','taskNr':'" + taskNr + "'}}}"));
 						if (fileId2!= null && source != null){
 							context = (JSONObject) p.parse(new String(
-				"{'extensions':{'https://tech4comp.de/xapi/context/extensions/file':{'id':'"
+				"{'extensions':{'https://xapi.tech4comp.dbis.rwth-aachen.de/definitions/generic/activities/file':{'id':'"
 						+ fileId + "','id2':'"
 						+ fileId2 + "','source':'"
 						+ source + "','topic':'"

--- a/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
+++ b/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
@@ -130,6 +130,9 @@ public class TmitocarService extends RESTService {
 
 	private static BasicDataSource dataSource;
 
+	private static String xapiUrl;
+	private static String xapiHomepage;
+
 	private final static String AUTH_FILE = "tmitocar/auth.json";
 
 
@@ -1341,7 +1344,7 @@ public class TmitocarService extends RESTService {
 			}
 			try{
 				JSONObject acc = (JSONObject) p.parse(new String("{'account': { 'name': '" + user
-					+ "', 'homePage': 'https://chat.tech4comp.dbis.rwth-aachen.de'}}"));
+					+ "', 'homePage': "+ xapiHomepage + "}}"));
 				
 				LrsCredentials res = service.getLrsCredentialsByCourse(courseId);
 				URL url = new URL(service.lrsURL + "/data/xAPI/statements?agent=" + acc.toString());
@@ -1384,9 +1387,9 @@ public class TmitocarService extends RESTService {
 						// JSONObject definition = (JSONObject) object.get("definition");
 						JSONObject extensions = (JSONObject) context.get("extensions");// assignmentNumber
 						// check if its not a delete statement
-						if (extensions.get("https://xapi.tech4comp.dbis.rwth-aachen.de/definitions/generic/extensions/context/assignment") != null && verb.get("id").toString().contains("sent")) {
+						if (extensions.get(xapiUrl + "/definitions/generic/extensions/context/assignment") != null && verb.get("id").toString().contains("sent")) {
 							JSONObject fileDetails = (JSONObject) extensions
-									.get("https://xapi.tech4comp.dbis.rwth-aachen.de/definitions/generic/extensions/context/assignment");
+									.get(xapiUrl + "/definitions/generic/extensions/context/assignment");
 							if (fileDetails.get("taskNr") != null) {
 								String assignmentName = fileDetails.get("taskNr").toString();
 								// JSONObject name = (JSONObject) definition.get("name");
@@ -1785,24 +1788,24 @@ public class TmitocarService extends RESTService {
 		JSONObject account = new JSONObject();
 
 		account.put("name", user);
-		account.put("homePage", "https://workbench.tech4comp.dbis.rwth-aachen.de");
+		account.put("homePage", xapiHomepage);
 		actor.put("account", account);
 		
 		JSONObject verb = (JSONObject) p
-				.parse(new String("{'display':{'en-US':'"+verbId+"'},'id':'https://xapi.tech4comp.dbis.rwth-aachen.de/definitions/chat/verbs/"+verbId+"'}"));
+				.parse(new String("{'display':{'en-US':'"+verbId+"'},'id':'" + xapiUrl + "/definitions/chat/verbs/" +verbId+"'}"));
 		JSONObject object = (JSONObject) p
 				.parse(new String("{'definition':{'interactionType':'other', 'name':{'en-US':'" + topic
 						+ "'}, 'description':{'en-US':'" + topic
-						+ "'}, 'type':'https://xapi.tech4comp.dbis.rwth-aachen.de/definitions/chat/activities/file'},'id':'https://tech4comp.de/tmitocar/file/"
+						+ "'}, 'type':'"+ xapiUrl + "/definitions/chat/activities/file'},'id':'https://tech4comp.de/tmitocar/file/"
 						+ fileId + "', 'objectType':'Activity'}"));
 		JSONObject context = (JSONObject) p.parse(new String(
-				"{'extensions':{'https://xapi.tech4comp.dbis.rwth-aachen.de/definitions/generic/extensions/context/assignment':{'id':'"
+				"{'extensions':{'" + xapiUrl + "/definitions/generic/extensions/context/assignment':{'id':'"
 						+ fileId + "','topic':'"
 						+ topic
 						+ "','course':'" + course + "','taskNr':'" + taskNr + "'}}}"));
 						if (fileId2!= null && source != null){
 							context = (JSONObject) p.parse(new String(
-				"{'extensions':{'https://xapi.tech4comp.dbis.rwth-aachen.de/definitions/generic/activities/file':{'id':'"
+				"{'extensions':{'"+ xapiUrl + "/definitions/generic/activities/file':{'id':'"
 						+ fileId + "','id2':'"
 						+ fileId2 + "','source':'"
 						+ source + "','topic':'"

--- a/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
+++ b/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
@@ -1797,7 +1797,7 @@ public class TmitocarService extends RESTService {
 		JSONObject object = (JSONObject) p
 				.parse(new String("{'definition':{'interactionType':'other', 'name':{'en-US':'" + topic
 						+ "'}, 'extensions':{'" + xapiUrl + "/definitions/mwb/object/course': {'id': " + course + "}}, 'description':{'en-US':'" + topic
-						+ "'}, 'type':'"+ xapiUrl + "/definitions/chat/activities/file'}, 'id': '" + fileId + "','objectType':'Activity'}"));
+						+ "'}, 'type':'"+ xapiUrl + "/definitions/chat/activities/file'}, 'id':'" + xapiUrl + "/definitions/chat/activities/file/" + fileId + "','objectType':'Activity'}"));
 		JSONObject context = (JSONObject) p.parse(new String(
 				"{'extensions':{'" + xapiUrl + "/definitions/mwb/extensions/context/activity_data':{'id':'"
 						+ fileId + "','topic':'"

--- a/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
+++ b/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
@@ -1387,9 +1387,9 @@ public class TmitocarService extends RESTService {
 						// JSONObject definition = (JSONObject) object.get("definition");
 						JSONObject extensions = (JSONObject) context.get("extensions");// assignmentNumber
 						// check if its not a delete statement
-						if (extensions.get(service.xapiUrl + "/definitions/generic/extensions/context/assignment") != null && verb.get("id").toString().contains("sent")) {
+						if (extensions.get(service.xapiUrl + "/definitions/mwb/extensions/context/activity_data") != null && verb.get("id").toString().contains("sent")) {
 							JSONObject fileDetails = (JSONObject) extensions
-									.get(service.xapiUrl + "/definitions/generic/extensions/context/assignment");
+									.get(service.xapiUrl + "/definitions/mwb/extensions/context/activity_data");
 							if (fileDetails.get("taskNr") != null) {
 								String assignmentName = fileDetails.get("taskNr").toString();
 								// JSONObject name = (JSONObject) definition.get("name");
@@ -1796,18 +1796,18 @@ public class TmitocarService extends RESTService {
 				.parse(new String("{'display':{'en-US':'"+verbId+"'},'id':'" + xapiUrl + "/definitions/chat/verbs/" +verbId+"'}"));
 		JSONObject object = (JSONObject) p
 				.parse(new String("{'definition':{'interactionType':'other', 'name':{'en-US':'" + topic
-						+ "'}, 'description':{'en-US':'" + topic
+						+ "'}, 'extensions:': {'" + xapiUrl + "/definitions/mwb/object/course': {'id': '" + course + "'}}, 'description':{'en-US':'" + topic
 						+ "'}, 'type':'"+ xapiUrl + "/definitions/chat/activities/file'},'id':'https://tech4comp.de/tmitocar/file/"
 						+ fileId + "', 'objectType':'Activity'}"));
 		JSONObject context = (JSONObject) p.parse(new String(
-				"{'extensions':{'" + xapiUrl + "/definitions/generic/extensions/context/assignment':{'id':'"
+				"{'extensions':{'" + xapiUrl + "/definitions/mwb/extensions/context/activity_data':{'id':'"
 						+ fileId + "','topic':'"
 						+ topic
 						+ "','course':'" + course + "','taskNr':'" + taskNr + "'}}}"));
 						if (fileId2!= null && source != null){
 							context = (JSONObject) p.parse(new String(
-				"{'extensions':{'"+ xapiUrl + "/definitions/generic/activities/file':{'id':'"
-						+ fileId + "','id2':'"
+				"{'extensions':{'"+ xapiUrl + "/definitions/mwb/extensions/context/activity_data':{'graphfileId':'"
+						+ fileId + "','feedbackId':'"
 						+ fileId2 + "','source':'"
 						+ source + "','topic':'"
 						+ topic

--- a/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
+++ b/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
@@ -364,7 +364,6 @@ public class TmitocarService extends RESTService {
 							if (uuid!=null){
 								// user has accepted
 							LrsCredentials lrsCredentials = getLrsCredentialsByCourse(Integer.parseInt(courseAndTask[0]));
-							System.out.println(lrsCredentials);
 							if(lrsCredentials!=null){
 								JSONObject xapi = prepareXapiStatement(uuid, "read", body.getTopic(), Integer.parseInt(courseAndTask[0]),Integer.parseInt(courseAndTask[1]),  graphFileId.toString(), feedbackFileId.toString(), sourceFileId);
 								String toEncode = lrsCredentials.getClientKey()+":"+lrsCredentials.getClientSecret();
@@ -1789,24 +1788,24 @@ public class TmitocarService extends RESTService {
 		JSONObject account = new JSONObject();
 
 		account.put("name", user);
-		account.put("homePage", xapiHomepage);
+		account.put("homePage", xapiHomepage.toString());
 		actor.put("account", account);
-		
+		System.out.println(account);
 		JSONObject verb = (JSONObject) p
-				.parse(new String("{'display':{'en-US':'"+verbId+"'},'id':'" + xapiUrl + "/definitions/chat/verbs/" +verbId+"'}"));
+				.parse(new String("{'display':{'en-US':'"+verbId+"'},'id':'" + xapiUrl.toString() + "/definitions/chat/verbs/" +verbId+"'}"));
 		JSONObject object = (JSONObject) p
 				.parse(new String("{'definition':{'interactionType':'other', 'name':{'en-US':'" + topic
 						+ "'}, 'description':{'en-US':'" + topic
-						+ "'}, 'type':'"+ xapiUrl + "/definitions/chat/activities/file'},'id':'https://tech4comp.de/tmitocar/file/"
+						+ "'}, 'type':'"+ xapiUrl.toString() + "/definitions/chat/activities/file'},'id':'https://tech4comp.de/tmitocar/file/"
 						+ fileId + "', 'objectType':'Activity'}"));
 		JSONObject context = (JSONObject) p.parse(new String(
-				"{'extensions':{'" + xapiUrl + "/definitions/generic/extensions/context/assignment':{'id':'"
+				"{'extensions':{'" + xapiUrl.toString() + "/definitions/generic/extensions/context/assignment':{'id':'"
 						+ fileId + "','topic':'"
 						+ topic
 						+ "','course':'" + course + "','taskNr':'" + taskNr + "'}}}"));
 						if (fileId2!= null && source != null){
 							context = (JSONObject) p.parse(new String(
-				"{'extensions':{'"+ xapiUrl + "/definitions/generic/activities/file':{'id':'"
+				"{'extensions':{'"+ xapiUrl.toString() + "/definitions/generic/activities/file':{'id':'"
 						+ fileId + "','id2':'"
 						+ fileId2 + "','source':'"
 						+ source + "','topic':'"
@@ -1822,6 +1821,7 @@ public class TmitocarService extends RESTService {
 		xAPI.put("actor", actor);
 		xAPI.put("object", object);
 		xAPI.put("verb", verb);
+		System.out.println(xAPI);
 		return xAPI;
 	}
 

--- a/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
+++ b/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
@@ -130,8 +130,8 @@ public class TmitocarService extends RESTService {
 
 	private static BasicDataSource dataSource;
 
-	private static String xapiUrl;
-	private static String xapiHomepage;
+	private String xapiUrl;
+	private String xapiHomepage;
 
 	private final static String AUTH_FILE = "tmitocar/auth.json";
 
@@ -1344,7 +1344,7 @@ public class TmitocarService extends RESTService {
 			}
 			try{
 				JSONObject acc = (JSONObject) p.parse(new String("{'account': { 'name': '" + user
-					+ "', 'homePage': '"+ xapiHomepage.toString() + "'}}"));
+					+ "', 'homePage': '"+ service.xapiHomepage + "'}}"));
 				
 				LrsCredentials res = service.getLrsCredentialsByCourse(courseId);
 				URL url = new URL(service.lrsURL + "/data/xAPI/statements?agent=" + acc.toString());
@@ -1387,9 +1387,9 @@ public class TmitocarService extends RESTService {
 						// JSONObject definition = (JSONObject) object.get("definition");
 						JSONObject extensions = (JSONObject) context.get("extensions");// assignmentNumber
 						// check if its not a delete statement
-						if (extensions.get(xapiUrl + "/definitions/generic/extensions/context/assignment") != null && verb.get("id").toString().contains("sent")) {
+						if (extensions.get(service.xapiUrl + "/definitions/generic/extensions/context/assignment") != null && verb.get("id").toString().contains("sent")) {
 							JSONObject fileDetails = (JSONObject) extensions
-									.get(xapiUrl + "/definitions/generic/extensions/context/assignment");
+									.get(service.xapiUrl + "/definitions/generic/extensions/context/assignment");
 							if (fileDetails.get("taskNr") != null) {
 								String assignmentName = fileDetails.get("taskNr").toString();
 								// JSONObject name = (JSONObject) definition.get("name");
@@ -1693,6 +1693,7 @@ public class TmitocarService extends RESTService {
 				response.append(line);
 			}
 			logger.info(response.toString());
+			System.out.println("XAPI Statement sent.");
 
 			conn.disconnect();
 		} catch (MalformedURLException e) {
@@ -1786,26 +1787,26 @@ public class TmitocarService extends RESTService {
 		JSONObject actor = new JSONObject();
 		actor.put("objectType", "Agent");
 		JSONObject account = new JSONObject();
-
+		System.out.println("Homepage is: " + xapiHomepage);
 		account.put("name", user);
-		account.put("homePage", xapiHomepage.toString());
+		account.put("homePage", xapiHomepage);
 		actor.put("account", account);
 		System.out.println(account);
 		JSONObject verb = (JSONObject) p
-				.parse(new String("{'display':{'en-US':'"+verbId+"'},'id':'" + xapiUrl.toString() + "/definitions/chat/verbs/" +verbId+"'}"));
+				.parse(new String("{'display':{'en-US':'"+verbId+"'},'id':'" + xapiUrl + "/definitions/chat/verbs/" +verbId+"'}"));
 		JSONObject object = (JSONObject) p
 				.parse(new String("{'definition':{'interactionType':'other', 'name':{'en-US':'" + topic
 						+ "'}, 'description':{'en-US':'" + topic
-						+ "'}, 'type':'"+ xapiUrl.toString() + "/definitions/chat/activities/file'},'id':'https://tech4comp.de/tmitocar/file/"
+						+ "'}, 'type':'"+ xapiUrl + "/definitions/chat/activities/file'},'id':'https://tech4comp.de/tmitocar/file/"
 						+ fileId + "', 'objectType':'Activity'}"));
 		JSONObject context = (JSONObject) p.parse(new String(
-				"{'extensions':{'" + xapiUrl.toString() + "/definitions/generic/extensions/context/assignment':{'id':'"
+				"{'extensions':{'" + xapiUrl + "/definitions/generic/extensions/context/assignment':{'id':'"
 						+ fileId + "','topic':'"
 						+ topic
 						+ "','course':'" + course + "','taskNr':'" + taskNr + "'}}}"));
 						if (fileId2!= null && source != null){
 							context = (JSONObject) p.parse(new String(
-				"{'extensions':{'"+ xapiUrl.toString() + "/definitions/generic/activities/file':{'id':'"
+				"{'extensions':{'"+ xapiUrl + "/definitions/generic/activities/file':{'id':'"
 						+ fileId + "','id2':'"
 						+ fileId2 + "','source':'"
 						+ source + "','topic':'"

--- a/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
+++ b/las2peer-tmitocar-service/src/main/java/i5/las2peer/services/tmitocar/TmitocarService.java
@@ -772,7 +772,7 @@ public class TmitocarService extends RESTService {
 
 					// Parse the JSON string into a JSONObject
 					JSONObject jsonObject = (JSONObject) parser.parse(jsonStr);
-					System.out.println("getCommonWords: \n")
+					System.out.println("getCommonWords: \n");
 					System.out.println(jsonObject);
 					String formattedMessage = "Danke, besprich das gern auch mit Kommiliton:innen und deinem/r Dozent:in. Wenn ich jetzt deinen Text und den Expertentext vergleiche, dann tauchen in beiden Texten folgende Begriffe als wesentlich auf:\n";
 					JSONArray bSchnittmengeArray = (JSONArray) jsonObject.get("BegriffeSchnittmenge");


### PR DESCRIPTION
Due to a new xAPI definitions website, the statements needed to be changed to the new xAPI URLs. To allow for flexible adaptations in the future, the xAPI Homepage and xAPI URL have been set to environment variables. The objects, context and verbs have been adapted according to the MWB.
The variable bSchnittmengenArray has been renamed to bDiffArray for getLabel2words. 